### PR TITLE
Add Single Media Property Resolver and displayOption handling and Tests

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolver.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\Resolver;
+namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
@@ -26,8 +26,15 @@ class MediaSelectionPropertyResolver implements PropertyResolverInterface
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
-        if (empty($data) || !\is_array($data) || !isset($data['ids'])) {
-            return ContentView::create([], ['ids' => []]);
+        $displayOption = (\is_array($data) && isset($data['displayOption']) && \is_string($data['displayOption']))
+            ? $data['displayOption']
+            : null;
+
+        if (!\is_array($data)
+            || !isset($data['ids'])
+            || !\array_is_list($data['ids'])
+        ) {
+            return ContentView::create([], ['ids' => [], 'displayOption' => $displayOption, ...$params]);
         }
 
         /** @var string $resourceLoaderKey */
@@ -36,7 +43,11 @@ class MediaSelectionPropertyResolver implements PropertyResolverInterface
         return ContentView::createResolvables(
             $data['ids'],
             $resourceLoaderKey,
-            ['ids' => $data['ids']],
+            [
+                'ids' => $data['ids'],
+                'displayOption' => $displayOption,
+                ...$params,
+            ],
         );
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver;
+
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Bundle\ContentBundle\Content\Application\PropertyResolver\PropertyResolverInterface;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
+
+/**
+ * @internal if you need to override this service, create a new service with based on ResourceLoaderInterface instead of extending this class
+ *
+ * @final
+ */
+class SingleMediaSelectionPropertyResolver implements PropertyResolverInterface
+{
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        $displayOption = (\is_array($data) && isset($data['displayOption']) && \is_string($data['displayOption']))
+            ? $data['displayOption']
+            : null;
+
+        if (!\is_array($data)
+            || !isset($data['id'])
+            || !\is_numeric($data['id'])
+        ) {
+            return ContentView::create(null, ['id' => null, 'displayOption' => $displayOption, ...$params]);
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? MediaResourceLoader::getKey();
+        $id = (int) $data['id'];
+
+        return ContentView::createResolvable(
+            $id,
+            $resourceLoaderKey,
+            [
+                'id' => $id,
+                'displayOption' => $displayOption,
+                ...$params,
+            ],
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'single_media_selection';
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolverTest.php
@@ -9,22 +9,22 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\CategoryBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\PropertyResolver\CategorySelectionPropertyResolver;
 use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\MediaSelectionPropertyResolver;
 
-#[CoversClass(CategorySelectionPropertyResolver::class)]
-class CategorySelectionPropertyResolverTest extends TestCase
+#[CoversClass(MediaSelectionPropertyResolver::class)]
+class MediaSelectionPropertyResolverTest extends TestCase
 {
-    private CategorySelectionPropertyResolver $resolver;
+    private MediaSelectionPropertyResolver $resolver;
 
     public function setUp(): void
     {
-        $this->resolver = new CategorySelectionPropertyResolver();
+        $this->resolver = new MediaSelectionPropertyResolver();
     }
 
     public function testResolveEmpty(): void
@@ -32,7 +32,7 @@ class CategorySelectionPropertyResolverTest extends TestCase
         $contentView = $this->resolver->resolve([], 'en');
 
         $this->assertSame([], $contentView->getContent());
-        $this->assertSame(['ids' => []], $contentView->getView());
+        $this->assertSame(['ids' => [], 'displayOption' => null], $contentView->getView());
     }
 
     public function testResolveParams(): void
@@ -42,17 +42,18 @@ class CategorySelectionPropertyResolverTest extends TestCase
         $this->assertSame([], $contentView->getContent());
         $this->assertSame([
             'ids' => [],
+            'displayOption' => null,
             'custom' => 'params',
         ], $contentView->getView());
     }
 
     #[DataProvider('provideUnresolvableData')]
-    public function testResolveUnresolvableData(mixed $data): void
+    public function testResolveUnresolvableData(mixed $data, ?string $expectedDisplayOption = null): void
     {
         $contentView = $this->resolver->resolve($data, 'en');
 
         $this->assertSame([], $contentView->getContent());
-        $this->assertSame(['ids' => []], $contentView->getView());
+        $this->assertSame(['ids' => [], 'displayOption' => $expectedDisplayOption], $contentView->getView());
     }
 
     /**
@@ -66,49 +67,64 @@ class CategorySelectionPropertyResolverTest extends TestCase
         yield 'smart_content' => [['source' => '123']];
         yield 'single_value' => [1];
         yield 'object' => [(object) [1, 2]];
+        yield 'int_list_not_in_ids' => [[1, 2]];
+        yield 'ids_null' => [['ids' => null]];
+        yield 'display_option_only' => [['displayOption' => 'left'], 'left'];
     }
 
     /**
-     * @param array<string|int> $data
+     * @param array{
+     *     ids?: array<string|int>,
+     *     displayOption?: string|null,
+     * } $data
      */
     #[DataProvider('provideResolvableData')]
-    public function testResolveResolvableData(array $data): void
+    public function testResolveResolvableData(array $data, ?string $expectedDisplayOption = null): void
     {
         $contentView = $this->resolver->resolve($data, 'en');
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
-        foreach ($data as $key => $value) {
+
+        foreach (($data['ids'] ?? []) as $key => $value) {
             $resolvable = $content[$key] ?? null;
             $this->assertInstanceOf(ResolvableResource::class, $resolvable);
             $this->assertSame($value, $resolvable->getId());
-            $this->assertSame('category', $resolvable->getResourceLoaderKey());
+            $this->assertSame('media', $resolvable->getResourceLoaderKey());
         }
 
-        $this->assertSame(['ids' => $data], $contentView->getView());
+        $this->assertSame([
+            'ids' => ($data['ids'] ?? []),
+            'displayOption' => $expectedDisplayOption,
+        ], $contentView->getView());
     }
 
     /**
      * @return iterable<array{
-     *     0: array<string|int>,
+     *     0: array{
+     *         ids: array<string|int>,
+     *         displayOption?: string|null,
+     *     },
      * }>
      */
     public static function provideResolvableData(): iterable
     {
         yield 'empty' => [[]];
-        yield 'int_list' => [[1, 2]];
-        yield 'string_list' => [['1', '2']];
+        yield 'int_list' => [['ids' => [1, 2]]];
+        yield 'int_list_with_display_option' => [['ids' => [1, 2], 'displayOption' => 'left'], 'left'];
+        yield 'string_list' => [['ids' => ['1', '2']]];
+        yield 'string_list_with_display_option' => [['ids' => ['1', '2'], 'displayOption' => 'left'], 'left'];
     }
 
     public function testCustomResourceLoader(): void
     {
-        $contentView = $this->resolver->resolve([1], 'en', ['resourceLoader' => 'custom_category']);
+        $contentView = $this->resolver->resolve(['ids' => [1]], 'en', ['resourceLoader' => 'custom_media']);
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
         $resolvable = $content[0] ?? null;
         $this->assertInstanceOf(ResolvableResource::class, $resolvable);
         $this->assertSame(1, $resolvable->getId());
-        $this->assertSame('custom_category', $resolvable->getResourceLoaderKey());
+        $this->assertSame('custom_media', $resolvable->getResourceLoaderKey());
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolverTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContentBundle\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\SingleMediaSelectionPropertyResolver;
+
+#[CoversClass(SingleMediaSelectionPropertyResolver::class)]
+class SingleMediaSelectionPropertyResolverTest extends TestCase
+{
+    private SingleMediaSelectionPropertyResolver $resolver;
+
+    public function setUp(): void
+    {
+        $this->resolver = new SingleMediaSelectionPropertyResolver();
+    }
+
+    public function testResolveEmpty(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en');
+
+        $this->assertSame(null, $contentView->getContent());
+        $this->assertSame(['id' => null, 'displayOption' => null], $contentView->getView());
+    }
+
+    public function testResolveParams(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en', ['custom' => 'params']);
+
+        $this->assertSame(null, $contentView->getContent());
+        $this->assertSame([
+            'id' => null,
+            'displayOption' => null,
+            'custom' => 'params',
+        ], $contentView->getView());
+    }
+
+    #[DataProvider('provideUnresolvableData')]
+    public function testResolveUnresolvableData(mixed $data, ?string $expectedDisplayOption = null): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $this->assertSame(null, $contentView->getContent());
+        $this->assertSame(['id' => null, 'displayOption' => $expectedDisplayOption], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: mixed,
+     * }>
+     */
+    public static function provideUnresolvableData(): iterable
+    {
+        yield 'null' => [null];
+        yield 'smart_content' => [['source' => '123']];
+        yield 'single_value' => [1];
+        yield 'object' => [(object) [1, 2]];
+        yield 'int_list_not_in_ids' => [[1, 2]];
+        yield 'ids_null' => [['ids' => null]];
+        yield 'ids_list' => [['ids' => [1, 2]]];
+        yield 'id_list' => [['id' => [1, 2]]];
+        yield 'display_option_only' => [['displayOption' => 'left'], 'left'];
+    }
+
+    /**
+     * @param array{
+     *     id?: string|int,
+     *     displayOption?: string|null,
+     * } $data
+     */
+    #[DataProvider('provideResolvableData')]
+    public function testResolveResolvableData(array $data, ?string $expectedDisplayOption = null): void
+    {
+        $contentView = $this->resolver->resolve($data, 'en');
+
+        $content = $contentView->getContent();
+        $id = $data['id'] ?? null;
+        if (null !== $id) {
+            $id = (int) $id;
+            $this->assertInstanceOf(ResolvableResource::class, $content);
+            $this->assertSame($id, $content->getId());
+            $this->assertSame('media', $content->getResourceLoaderKey());
+        }
+
+        $this->assertSame([
+            'id' => $id,
+            'displayOption' => $expectedDisplayOption,
+        ], $contentView->getView());
+    }
+
+    /**
+     * @return iterable<array{
+     *     0: array{
+     *         id: string|int,
+     *         displayOption?: string|null,
+     *     },
+     * }>
+     */
+    public static function provideResolvableData(): iterable
+    {
+        yield 'empty' => [[]];
+        yield 'int_id' => [['id' => 1]];
+        yield 'int_id_with_display_option' => [['id' => 1, 'displayOption' => 'left'], 'left'];
+        yield 'string_id' => [['id' => '1']];
+        yield 'string_id_with_display_option' => [['id' => '1', 'displayOption' => 'left'], 'left'];
+    }
+
+    public function testCustomResourceLoader(): void
+    {
+        $contentView = $this->resolver->resolve(['ids' => [1]], 'en', ['resourceLoader' => 'custom_media']);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $resolvable = $content[0] ?? null;
+        $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+        $this->assertSame(1, $resolvable->getId());
+        $this->assertSame('custom_media', $resolvable->getResourceLoaderKey());
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/MediaResourceLoaderTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/MediaResourceLoaderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\MediaBundle\Api\Media as ApiMedia;
+use Sulu\Bundle\MediaBundle\Entity\Media;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
+use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+
+class MediaResourceLoaderTest extends TestCase
+{
+    use ProphecyTrait;
+    use SetGetPrivatePropertyTrait;
+
+    /**
+     * @var ObjectProphecy<MediaManagerInterface>
+     */
+    private ObjectProphecy $mediaManager;
+
+    private MediaResourceLoader $loader;
+
+    public function setUp(): void
+    {
+        $this->mediaManager = $this->prophesize(MediaManagerInterface::class);
+        $this->loader = new MediaResourceLoader($this->mediaManager->reveal());
+    }
+
+    public function testGetKey(): void
+    {
+        $this->assertSame('media', $this->loader::getKey());
+    }
+
+    public function testLoad(): void
+    {
+        $media1 = $this->createMedia(1);
+        $media2 = $this->createMedia(3);
+
+        $this->mediaManager->getByIds([1, 3], 'en')->willReturn([
+            $media1,
+            $media2,
+        ])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load([1, 3], 'en', []);
+
+        $this->assertSame([
+            1 => $media1,
+            3 => $media2,
+        ], $result);
+    }
+
+    private static function createMedia(int $id): ApiMedia
+    {
+        $media = new Media();
+        static::setPrivateProperty($media, 'id', $id);
+
+        return new ApiMedia($media, 'en');
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | requires #1 #2, PR for: https://github.com/sulu/sulu/pull/7611
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add resolver for single media selection.

#### Why?

See https://github.com/Prokyonn/sulu/pull/1 and https://github.com/sulu/sulu/pull/7611 and https://github.com/sulu/SuluContentBundle/pull/271

#### TODO

 - [x] Tests