### PR TITLE
Resolve tags by name instead of id

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCategorySelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleCategorySelectionPropertyResolver.php
@@ -26,7 +26,7 @@ class SingleCategorySelectionPropertyResolver implements PropertyResolverInterfa
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
-        if (!\is_string($data) || '' === $data) {
+        if (!\is_int($data)) {
             return ContentView::create([], $params);
         }
 

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services_content.xml
@@ -10,7 +10,7 @@
         </service>
 
         <service id="sulu_category.single_category_selection_property_resolver"
-                 class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\PropertyResolver\CategorySelectionPropertyResolver">
+                 class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\PropertyResolver\SingleCategorySelectionPropertyResolver">
 
             <tag name="sulu_content.property_resolver"/>
         </service>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_content.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <!-- Property Resolver -->
         <service id="sulu_media.media_selection_property_resolver"
@@ -22,12 +22,29 @@
             <tag name="sulu_content.property_resolver"/>
         </service>
 
+        <service id="sulu_media.collection_selection_property_resolver"
+                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\CollectionSelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
+        <service id="sulu_media.single_collection_selection_property_resolver"
+                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\SingleCollectionSelectionPropertyResolver">
+            <tag name="sulu_content.property_resolver"/>
+        </service>
+
         <!-- Resource Loader -->
         <service id="sulu_media.media_resource_loader"
                  class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader">
             <argument type="service" id="sulu_media.media_manager"/>
 
             <tag name="sulu_content.resource_loader" type="media"/>
+        </service>
+
+        <service id="sulu_media.collection_resource_loader"
+                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\CollectionResourceLoader">
+            <argument type="service" id="sulu_media.collection_manager"/>
+
+            <tag name="sulu_content.resource_loader" type="collection"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/TagBundle/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoader.php
+++ b/src/Sulu/Bundle/TagBundle/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoader.php
@@ -32,11 +32,11 @@ class TagResourceLoader implements ResourceLoaderInterface
 
     public function load(array $ids, ?string $locale, array $params = []): array
     {
-        $result = $this->tagRepository->findBy(['id' => $ids]);
+        $result = $this->tagRepository->findBy(['name' => $ids]);
 
         $mappedResult = [];
         foreach ($result as $tag) {
-            $mappedResult[$tag->getId()] = $tag->getName();
+            $mappedResult[$tag->getName()] = $tag->getName();
         }
 
         return $mappedResult;

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoaderTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/TagResourceLoaderTest.php
@@ -47,17 +47,17 @@ class TagResourceLoaderTest extends TestCase
         $tag1 = $this->createTag(1);
         $tag2 = $this->createTag(3);
 
-        $this->tagRepository->findBy(['id' => [1, 3]])->willReturn([
+        $this->tagRepository->findBy(['name' => ['Tag 1', 'Tag 3']])->willReturn([
             $tag1,
             $tag2,
         ])
             ->shouldBeCalled();
 
-        $result = $this->loader->load([1, 3], 'en', []);
+        $result = $this->loader->load(['Tag 1', 'Tag 3'], 'en', []);
 
         $this->assertSame([
-            1 => $tag1->getName(),
-            3 => $tag2->getName(),
+            'Tag 1' => $tag1->getName(),
+            'Tag 3' => $tag2->getName(),
         ], $result);
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes

#### What's in this PR?

Resolve tags by name instead of id.

#### Why?

Because the react admin always works with the `name` of the tag instead of the id.

#### To Do

- [x] Update tests
